### PR TITLE
Patch of certbot files

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ systemctl enable event_service
 systemctl start event_service
 ```
 
+Note: certbot files need to be moved to the appropriate /etc/letsencrypt directory.  
+
 ### Run Manually
 ```bash
 java -jar event_service-<version>.jar

--- a/letsencrypt/renewal-hooks/deploy/deploy.sh
+++ b/letsencrypt/renewal-hooks/deploy/deploy.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+/opt/event_service/scripts/letsencrypt_to_pkcs12.sh
+

--- a/letsencrypt/renewal-hooks/post/start.sh
+++ b/letsencrypt/renewal-hooks/post/start.sh
@@ -2,7 +2,5 @@
 
 set -e
 
-/opt/event_service/scripts/letsencrypt_to_pkcs12.sh
-
 /etc/init.d/event_service start
 

--- a/letsencrypt/renewal-hooks/post/start.sh
+++ b/letsencrypt/renewal-hooks/post/start.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+/opt/event_service/scripts/letsencrypt_to_pkcs12.sh
+
+/etc/init.d/event_service start
+

--- a/letsencrypt/renewal-hooks/pre/stopjava.sh
+++ b/letsencrypt/renewal-hooks/pre/stopjava.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+/etc/init.d/event_service stop

--- a/scripts/letsencrypt_to_pkcs12.sh
+++ b/scripts/letsencrypt_to_pkcs12.sh
@@ -4,8 +4,8 @@
 
 NAME=event.nova-labs.org
 PEM_DIR=/etc/letsencrypt/live/$NAME
+EVENT_DIR=/opt/event_service
 
-openssl pkcs12 -export -in ${PEM_DIR}/fullchain.pem -inkey ${PEM_DIR}/privkey.pem -out ${NAME}.p12 -name $NAME -CAfile chain.pem -caname root
-
+openssl pkcs12 -export -in ${PEM_DIR}/fullchain.pem -inkey ${PEM_DIR}/privkey.pem -out ${EVENT_DIR}/${NAME}.p12 -name $NAME -CAfile chain.pem -caname root -passout pass:novalabs
 
 


### PR DESCRIPTION
Fixed the certbot files to allow automatic updates
- stopjava.sh - stops java and web server 
- deploy.sh - makes the downloaded cert work for java event service
- start.sh - restarts event service and apache